### PR TITLE
Canonical emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'chewy', '~> 5.0'
 gem 'cld3', '~> 3.2.0'
 gem 'devise', '~> 4.4'
 gem 'devise-two-factor', '~> 3.0'
+gem 'email_address'
 
 group :pam_authentication, optional: true do
   gem 'devise_pam_authenticatable2', '~> 9.1'

--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ group :development, :test do
 end
 
 group :production, :test do
-  gem 'private_address_check', '~> 0.4.1'
+  gem 'private_address_check', '~> 0.5.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,9 @@ GEM
     elasticsearch-transport (6.0.2)
       faraday
       multi_json
+    email_address (0.1.11)
+      netaddr (~> 2.0)
+      simpleidn
     encryptor (3.0.0)
     equatable (0.5.0)
     erubi (1.7.1)
@@ -346,6 +349,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
+    netaddr (2.0.3)
     newrelic_rpm (5.1.0.344)
     nio4r (2.3.0)
     nokogiri (1.8.2)
@@ -572,6 +576,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    simpleidn (0.1.1)
+      unf (~> 0.1.4)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -676,6 +682,7 @@ DEPENDENCIES
   devise_pam_authenticatable2 (~> 9.1)
   doorkeeper (~> 4.3)
   dotenv-rails (~> 2.2, < 2.3)
+  email_address
   fabrication (~> 2.20)
   faker (~> 1.8)
   fast_blank (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,7 +408,7 @@ GEM
     premailer-rails (1.10.2)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
-    private_address_check (0.4.1)
+    private_address_check (0.5.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -731,7 +731,7 @@ DEPENDENCIES
   pkg-config (~> 1.3)
   posix-spawn (~> 0.3)
   premailer-rails
-  private_address_check (~> 0.4.1)
+  private_address_check (~> 0.5.0)
   pry-byebug (~> 3.6)
   pry-rails (~> 0.3)
   puma (~> 3.11)

--- a/db/migrate/20180803045717_add_canonical_email_to_users.rb
+++ b/db/migrate/20180803045717_add_canonical_email_to_users.rb
@@ -1,0 +1,14 @@
+class AddCanonicalEmailToUsers < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :canonical_email, :string
+
+    transaction do
+      User.find_each do |user|
+        user.update_attribute(:canonical_email, EmailAddress.canonical(user.email))
+      end
+    end
+    add_index :users, :canonical_email, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_09_045412) do
+ActiveRecord::Schema.define(version: 2018_08_03_045717) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -522,7 +522,9 @@ ActiveRecord::Schema.define(version: 2018_05_09_045412) do
     t.boolean "moderator", default: false, null: false
     t.bigint "invite_id"
     t.string "remember_token"
+    t.string "canonical_email"
     t.index ["account_id"], name: "index_users_on_account_id"
+    t.index ["canonical_email"], name: "index_users_on_canonical_email"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["filtered_languages"], name: "index_users_on_filtered_languages", using: :gin

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe User, type: :model do
       expect(user.valid?).to be true
     end
 
+    it 'is invalid for normalized email that has been used' do
+      Fabricate(:user, email: 'john.smith@gmail.com')
+
+      %w(johnsmith@gmail.com john.smith+sneaky@gmail.com j.ohnsmith@gmail.com).each do |email|
+        user = Fabricate.build(:user, email: email)
+        expect(user).to_not be_valid
+        expect(user).to model_have_error_on_field(:email)
+      end
+
+      expect(Fabricate.build(:user, email: 'not.john.smith@gmail.com')).to be_valid
+    end
+
     it 'cleans out empty string from languages' do
       user = Fabricate.build(:user, filtered_languages: [''])
       user.valid?


### PR DESCRIPTION
Spammers are abusing the `.` and `+` of email providers to sign up for multiple accounts. Make it so they can't.